### PR TITLE
Support musl targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,16 @@ jobs:
               os: ubuntu-20.04,
               use-cross: true,
             }
-
+          - {
+              target: aarch64-unknown-linux-musl,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
+          - {
+              target: x86_64-unknown-linux-musl,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
           - {
               target: arm-unknown-linux-gnueabihf,
               os: ubuntu-20.04,

--- a/native/sqlparser_parse/.cargo/config.toml
+++ b/native/sqlparser_parse/.cargo/config.toml
@@ -3,3 +3,13 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]

--- a/native/sqlparser_parse/Cross.toml
+++ b/native/sqlparser_parse/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]


### PR DESCRIPTION
Hello !

First of all, thank you for that project, it is really nice :)

However, to be able to use it, we would need to have the `-musl` builds which are missing. I see that they have been removed in [this commit](https://github.com/maartenvanvliet/sql_parser/commit/248a9680b44abd3f85082eade43a5de4fe3c4183). I'm not sure if there is a specific reason besides the fact that the compilation could not work without the appropriate options.

In any case, if you agree to add it, this PR should make it work (it did work [on our fork](https://github.com/Digazu/sql_parser/actions/runs/4720794762/jobs/8373278124)).

I have also added the `Cross.toml` file, which is mentioned in the [Precompilation guide](https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#additional-configuration-before-build). I am not sure the `RUSTLER_NIF_VERSION` is actually used without that file.